### PR TITLE
ci: add publish.yaml

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,27 @@
+name: Publish Package to npmjs
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: package.json
+          cache: npm
+          registry-url: https://registry.npmjs.org
+
+      - run: npm ci
+
+      - run: npm run release

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+save-exact=true
+save-prefix=""
+provenance=true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,3 +34,27 @@ In the n8n-nodes-craftmypdf directory, run
 3. Open n8n via `http://localhost:5678/`. You should see the "CraftMyPdf" node when you search for it.
 
    ![2024-11-01_22-31](https://github.com/user-attachments/assets/1c522a6b-a77a-4163-8911-a9ed0fb4a290)
+
+# Release a new version
+
+1. Update the `version` field in `package.json` using [`npm version`](https://docs.npmjs.com/cli/v11/commands/npm-version) command.
+
+   For example:
+
+   ```
+   # For patch version update, e.g. 0.1.1 to 0.1.2
+   npm version patch
+
+   # For minor version update, e.g. 0.1.1 to 0.2.0
+   npm version minor
+   ```
+
+   The `npm version` command will create a version commit and tag.
+
+2. Push the commit and tag
+
+   ```
+   git push --follow-tags
+   ```
+
+3. The NPM Publish job will be triggered at https://github.com/CraftMyPDF/n8n-nodes-craftmypdf/actions/workflows/publish.yaml

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/craftmypdf/n8n-nodes-craftmypdf.git"
+		"url": "git+https://github.com/CraftMyPDF/n8n-nodes-craftmypdf.git"
 	},
 	"engines": {
 		"node": ">=24.14",


### PR DESCRIPTION
As of 17 March 2026, according to https://docs.n8n.io/integrations/creating-nodes/deploy/submit-community-nodes/#standards:

> From May 1st 2026 you must publish **ALL** community nodes using a GitHub action and include a [provenance statement](https://docs.npmjs.com/generating-provenance-statements)

@bktan81 Required settings:

1. Go to the Settings tab of https://www.npmjs.com/package/n8n-nodes-craftmypdf

2. Set the following fields:

   1. Organization: CraftMyPDF
   2. Repository: n8n-nodes-craftmypdf
   3. Workflow filename: publish.yaml

   <img width="1224" height="760" alt="2026-03-17_14-21" src="https://github.com/user-attachments/assets/8c7c8579-5344-4cb8-bb01-e6357c4f34b3" />

4. For **Publishing access** setting, set to **Require two-factor authentication and disallow tokens (recommended)**, then click **Update Package Settings**

   <img width="862" height="374" alt="2026-03-17_14-21_1" src="https://github.com/user-attachments/assets/cc33e5f7-8a76-46c3-a0b4-d1fcbcaf03cd" />


Reference: https://docs.npmjs.com/generating-provenance-statements
Reference: https://docs.npmjs.com/trusted-publishers#for-github-actions